### PR TITLE
Set build configuration for XBuild use.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -42,7 +42,8 @@ Task("Build")
     else
     {
       // Use XBuild
-      XBuild("./src/Example.sln");
+      XBuild("./src/Example.sln", settings =>
+        settings.SetConfiguration(configuration));
     }
 });
 


### PR DESCRIPTION
When someone on an XBuild system follows along with the [getting-started instructions](http://cakebuild.net/docs/tutorials/getting-started) and do the "Bonus points" section, they get a very quiet failure buried in what appears to be a successful build.

```
========================================
Run-Unit-Tests
========================================
Executing task: Run-Unit-Tests
… {NUnit initial output} …

fatal error: no inputs specified

… {NUnit usage output} …
Finished executing task: Run-Unit-Tests
```

Since the build configuration isn't set for XBuild calls, the unit tests were built to /Debug by default despite `configuration` being set to "Release" at the top of the file. As a result, `NUnit("./src/**/bin/" + configuration + "/*.Tests.dll");` would look in /Release, not find any files, and NUnit would fail. Since this failure doesn't seem to result in a failing return code from NUnit, it will appear as if everything worked just fine. (Even less obvious, if someone had previously built the unit tests to /Release without cleaning those files out, it would incorrectly run NUnit against DLLs built prior to the build script execution.)

Explicitly setting the configuration for XBuild just like it is done for MSBuild in the other side of the conditional a few lines earlier resolves the issue.
