### PR TITLE
Updates to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ done
 # Download NuGet if it does not exist.
 if [ ! -f $NUGET_EXE ]; then
     echo "Downloading NuGet..."
-    curl -Lsfo $NUGET_EXE https://www.nuget.org/nuget.exe
+    curl -Lsfo $NUGET_EXE https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+PACKAGES_CONFIG=$TOOLS_DIR/packages.config
 
 # Define default arguments.
 SCRIPT="build.cake"
@@ -17,6 +18,7 @@ CONFIGURATION="Release"
 VERBOSITY="verbose"
 DRYRUN=false
 SHOW_VERSION=false
+
 
 # Parse arguments.
 for i in "$@"; do
@@ -39,6 +41,16 @@ if [ ! -f $NUGET_EXE ]; then
     curl -Lsfo $NUGET_EXE https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+# Download tools/packages.config if it doesn't exist
+if [ ! -f $PACKAGES_CONFIG ]; then
+    echo "Downloading packages.config"
+    curl -Lsfo $PACKAGES_CONFIG http://cakebuild.net/download/bootstrapper/packages
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading packages.config"
         exit 1
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,8 @@ for i in "$@"; do
     shift
 done
 
+mkdir -p $TOOLS_DIR
+
 # Download NuGet if it does not exist.
 if [ ! -f $NUGET_EXE ]; then
     echo "Downloading NuGet..."


### PR DESCRIPTION
1. Update the NuGet Version
2. build.sh will fail if the tools directory doesn't exist (so make sure it's there)
3. make sure the packages.config is in the tools directory (similar to the powershell script but in bash)
