### PR TITLE
Fix parameter passing

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -185,5 +185,24 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+
+$CAKE_ARGS = @($Script, "-target=$Target", "-configuration=$Configuration", "-verbosity=$Verbosity")
+
+if ($UseMono) {
+    $CAKE_ARGS += @($UseMono)
+}
+
+if ($UseDryRun) {
+    $CAKE_ARGS += @($UseDryRun)
+}
+
+if ($UseExperimental) {
+    $CAKE_ARGS += @($UseExperimental)
+}
+
+if ($ScriptArgs -ne $null) {
+    $CAKE_ARGS += $ScriptArgs
+}
+
+& $CAKE_EXE $CAKE_ARGS
 exit $LASTEXITCODE


### PR DESCRIPTION
Currently an expression if built up and evaluates, this causes issues when certain parameters are passed. Changed the bootstrapper script to built up an array with parameters, which Powershell escapes automatically. Fixes [#1069](https://github.com/cake-build/cake/issues/1069).
