### PR TITLE
Update build.ps1 to use SHA1 instead of MD5

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -65,10 +65,10 @@ function MD5HashFile([string] $filePath)
     }
 
     [System.IO.Stream] $file = $null;
-    [System.Security.Cryptography.MD5] $md5 = $null;
+    [System.Security.Cryptography.SHA1] $md5 = $null;
     try
     {
-        $md5 = [System.Security.Cryptography.MD5]::Create()
+        $md5 = [System.Security.Cryptography.SHA1]::Create()
         $file = [System.IO.File]::OpenRead($filePath)
         return [System.BitConverter]::ToString($md5.ComputeHash($file))
     }


### PR DESCRIPTION
This change is necessary for use on FIPS compliant servers