### PR TITLE
Add parameter for setting Cake NuGet restore path

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,6 +31,8 @@ Uses the nightly builds of the Roslyn script engine.
 Uses the Mono Compiler rather than the Roslyn script engine.
 .PARAMETER SkipToolPackageRestore
 Skips restoring of packages.
+.PARAMETER CakeDir
+Restore path for Cake NuGet packages.
 .PARAMETER ScriptArgs
 Remaining arguments are added here.
 
@@ -52,6 +54,7 @@ Param(
     [switch]$Experimental,
     [switch]$Mono,
     [switch]$SkipToolPackageRestore,
+	[string]$CakeDir,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
@@ -96,7 +99,14 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+# Set Cake NuGet restore path
+if ($CakeDir){
+	$TOOLS_DIR = Join-Path $PSScriptRoot $CakeDir
+}
+else{
+	$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+}
+
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"


### PR DESCRIPTION
You are now able to set the path for NuGet restore of Cake dependencies explicitly.

Example batch call:
```
powershell -command ".\build.ps1 -CakeDir \"./tmpCakeArtifacts\"" 
pause
```
This would restore all Cake dependencies (like `Cake.exe`, ...) inti the `tmpCakeArtifacts` directory instead of the default `tools` folder. It is espacially useful if you execute the buildscript in your workspace where you already have a folder named `tools` and you don't want the script to delete the content every time it runs.