### PR TITLE
Corrected link to getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository is used as an minimal example of using the [Cake build system](https://cakebuild.net)
 
-You can read more in the Cake [Getting Started guide](https://cakebuild.net/docs/tutorials/getting-started).
+You can read more in the Cake [Getting Started guide](https://cakebuild.net/docs/getting-started/setting-up-a-new-project).
 
 [![Build Status](https://ci.appveyor.com/api/projects/status/dfi1xib48d9diiac?svg=true)](https://ci.appveyor.com/project/cakebuild/example)


### PR DESCRIPTION
Tried to use the getting started guide link and found it was broken, I have included the corrected link to the guide.